### PR TITLE
fix: publish compile_catalog

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,7 +16,12 @@ jobs:
           pip install setuptools wheel babel
       - name: Build package
         run: |
-          python setup.py compile_catalog sdist bdist_wheel
+          python setup.py sdist bdist_wheel
+
+          if grep -q "compile_catalog" setup.cfg
+          then
+            python setup.py compile_catalog
+          fi
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@v1.5.1
         with:


### PR DESCRIPTION
* compile_catalog isn't necessary in every package. it has to be checked
  if the configuration is done in the setup.cfg file, otherwise don't do
  it
