### PR TITLE
fix: python3.12 has not more installed setuptools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Generate dependencies
         run: |
-          pip install wheel requirements-builder
+          pip install wheel setuptools requirements-builder
           requirements-builder -e "tests" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
           cat .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
       - name: Cache pip


### PR DESCRIPTION
* due to the release notes of python3.12 setuptools has to be installed
  explicitly to get the pkg_resources package
