### PR TITLE
allow other build backends to be used with publishing workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,29 +1,55 @@
 on:
   workflow_call:
+    inputs:
+      translation_directory:
+        description: directory babel translations reside in, passed to pybabel compile --directory=...
+        required: false
+        type: string
 
 jobs:
   build-n-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Checkout the code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel babel
-      - name: Build package
+          uv pip install babel build
+
+      - name: Compile translations
+        env:
+          # writing input to env-var prevents injection-attacks
+          # this is suggested by github-documentation's section `Security hardening for GitHub Actions`
+          TRANSLATION_DIRECTORY: ${{inputs.translation_directory}}
         run: |
-          if grep -q "compile_catalog" setup.cfg
+          if [[ -f setup.cfg ]] && grep -q "compile_catalog" setup.cfg
           then
             python setup.py compile_catalog
+          elif [[ -n "$TRANSLATION_DIRECTORY" ]]
+          then
+            if [[ ! -d "$TRANSLATION_DIRECTORY" ]]
+            then
+              echo "given translation-directory `$TRANSLATION_DIRECTORY` does not exist"
+              exit 1
+            fi
+            pybabel compile --directory="$TRANSLATION_DIRECTORY" --use-fuzzy
           fi
 
-          python setup.py sdist bdist_wheel
+      - name: Build package
+        run: |
+          python -m build
+
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
### current situation
we currently:
- build disributions via `python setup.py sdist wheel`
- compile translations via `python setup.py compile_catalog`

both of these only work when using `setuptools` and its `setup.py` file

we want to allow build-backends other than `setuptools`, e.g. `hatchling` which allows LSPs to work with editably installed packages

### changes
- use the build-frontend `build` for building distributions
  build-fronteds use the (build-backend and build-dependencies) specified in `pyproject.toml`'s `build-system` table
- to compile translations, allow direct use of `babel`'s `pybabel` CLI  (instead of requiring the `setuptools` wrapper CLI)
- use `uv` as package-installer
- version bumps for `python` and `pypa/gh-action-pypi-publish`

### references
- ad version bump of `pypa/gh-action-pypi-publish`:
  [Release Log](https://github.com/pypa/gh-action-pypi-publish/releases)
  relevant here is `v1.12.0` which cuts 30 seconds off the publishing action
- purpose of setting `inputs.translation_directory` to an environment-variable is to guard against injection-attacks
  see [relevant section](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) of github's documentation
- I've tested these workflows on my own github repository
  [link to repo](https://github.com/martinobersteiner/workflow-tests), [link to workflow run](https://github.com/martinobersteiner/workflow-tests/actions/runs/13521505627/job/37781632038)
  this contains an example calling workflow and a called workflow like these changes propose
  the above-linked calling workflow was manually triggered on current main branch

### design considerations
`translation-directory` must be mentioned somewhere (cannot be computed without being read from somewhere)
currently, `translation-directory` is read from (the `setuptools`-only) `setup.cfg` file
this change allows to alternatively pass `translation-directory` as an argument to `pypi-publish` workflow
most direct way to use this is to simply hardcode the `translation-directory` argument where the `pypi-publish` workflow is called (this is what the above-referenced exampling calling workflow does)

looking up the `translation-directory` from some configuration-file instead can easily be added later, should the need arise