### PR TITLE
fix: fix uv's cache-warning by disabling cache

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
+          enable-cache: false
           python-version: 3.12
 
       - name: Install dependencies


### PR DESCRIPTION
currently, when publishing, `astral-sh/setup-uv` shows a warning about incorrect caching configuration

caching behavior by the github-action `astral-sh/setup-uv` is as follows:
- the action caches things in github-cache
- the action invalidates cache whenever *watched* files change
- per default, *watched* files are `[**/uv.lock,**/requirements*.txt]`
- no such files exist, *which causes the warning*

`astral-sh/setup-uv` caches the following things:
- the `uv` executable itself
- source-built python-packages installed with `uv pip install`
   (not pre-built packages though, because *"On GitHub-hosted runners, it's typically faster to omit those pre-built wheels from the cache [...]"*[[1]](https://github.com/astral-sh/setup-uv?tab=readme-ov-file#disable-cache-pruning))

for us, caching slows things down actually:
- looking up github-cache takes longer than just redownloading the `uv` executable
- all packages we install (namely `built` and `babel`) come pre-built and hence aren't cached
- we incur overhead for handling caching

this PR hence disables caching to fix the warning